### PR TITLE
initialized lastVisionResult with a non-null value

### DIFF
--- a/src/main/java/frc/robot/Subsystems/Vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/Subsystems/Vision/VisionSubsystem.java
@@ -20,7 +20,7 @@ public class VisionSubsystem extends SubsystemBase {
 
     private final PhotonCamera instanceCamera;
     private final PhotonPoseEstimator photonPoseEstimator;
-    private Optional<VisionData> lastVisionResult;
+    private Optional<VisionData> lastVisionResult = Optional.empty();
 
     public VisionSubsystem() {
         photonPoseEstimator = new PhotonPoseEstimator(


### PR DESCRIPTION
lastVisionResult was null on startup and was causing a crash when it was supplied to the drive subsystem, I gave it a starting value of empty so that is wouldn't happen